### PR TITLE
Fix underline styling on add button

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -255,6 +255,7 @@ ul[aria-label]::before {
   cursor: pointer;
   width: 35px;
   height: 35px;
+  text-decoration: none;
 }
 
 #blog-post-add .material-symbols-outlined {


### PR DESCRIPTION
Remove unwanted underline from the add button by adding text-decoration: none to the #blog-post-add CSS rule.

🤖 Generated with [Claude Code](https://claude.ai/code)